### PR TITLE
Dalenard21 patch feb 5 release for help center

### DIFF
--- a/_includes/components/nav/sidenav.html
+++ b/_includes/components/nav/sidenav.html
@@ -116,6 +116,11 @@
       </a>
     </li>
     <li>
+      <a {% if page.sidenav == 'cancel-opportunity' %}class="usa-current"{% endif %} href="{{ '/opportunity-creators/cancel-opportunity' | relative_url }}">
+        How to cancel an opportunity
+      </a>
+    </li>
+    <li>
       <a {% if page.sidenav == 'opportunity-complete-oppportunity' %}class="usa-current"{% endif %} href="{{ '/opportunity-creators/complete-opportunity' | relative_url }}">
         How to complete and close out an opportunity
       </a>

--- a/applicants/find.md
+++ b/applicants/find.md
@@ -38,9 +38,11 @@ An opportunity that’s “open” is accepting applicants. The work has not yet
 
 An opportunity that’s “in progress” has already started. Participants have been assigned and are working on the opportunity. You can’t apply to an opportunity that’s “in progress”.
 
-#### Completed
+### Profile match
 
-An opportunity that’s “completed” is done. The work has been completed and you can no longer apply to the opportunity.
+We use Skills Engine ™ to analyze the skills you list in your profile and the skills needed for an opportunity. We will highlight opportunities based on how well your skills match. The matching can range from **Good** to **Better** to **Best**. 
+
+You can apply to any opportunity, even ones that don’t show as a match, and the opportunity creator will not know if you match the opportunity. Use the profile match as a guideline to understand which opportunities might be a good fit for your skills. 
 
 ### Community
 

--- a/opportunity-creators/cancel-opportunity.md
+++ b/opportunity-creators/cancel-opportunity.md
@@ -1,0 +1,18 @@
+---
+permalink: opportunity/cancel-opportunity/
+layout: article
+section: opportunity
+category: opportunity
+sidenav: cancel-opportunity
+title: How to cancel an opportunity
+---
+If you are an opportunity creator or a sitewide or community administrator, you can cancel an opportunity as long as it's not already complete. The status will change to **Canceled**, but you can reopen or duplicate it later. Canceled opportunities will also continue to appear on the creators' dashboard. 
+
+To cancel an opportunity:
+
+1. Open the opportunity.
+2. Scroll to the bottom right of the opportunity detail page.
+3. Click **Cancel this opportunity**.
+4. Click **Confirm**.
+
+We will send an email to all applicants or participants letting them know the opportunity is canceled.

--- a/profile/badges.md
+++ b/profile/badges.md
@@ -10,7 +10,7 @@ title: What are badges?
 You can earn badges by participating in or creating an opportunity. We award badges when all participant tasks are complete and the opportunity creator clicks Complete on the opportunity.
 
 ## Badges for applicants
-You may receive a badge if you participate in an opportunity. The different badges are based on the number of opportunities you complete.
+You may receive a badge for participating in an opportunity. The different badges are based on the number of opportunities you complete.
 
 ### Newcomer
 You get the Newcomer badge after you complete your first opportunity.
@@ -44,3 +44,10 @@ You may receive a badge if you’re a community manager.
 
 ### Community manager
 You’ll get the Community manager badge if you assist with the administration of a community. A sitewide administrator or another community manager will award this badge.
+
+## Badges for anyone
+### Ambassador
+Only Administrators and Community managers can award this badge to someone. 
+
+You’ll get the Ambassador badge if you are a champion of Open Opportunities or of a specific community within Open Opportunities. You help get the word out through marketing, promoting and being a pro-active supporter of the program.
+

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -15,6 +15,7 @@ title: What's new with Open Opportunities
 * Added a **Good**, **Better** and **Best** indicator to matching opportunities. This helps a user know how well an opportunity matches their profile.
 * Updated the search results default to sort by **Profile match**.
 * Added a new **Profile match** filter on the search page to filter opportunities by good, better, and best match.
+* Removed completed opportunities from skills search filters to improve system performance
 
 ### Other
 

--- a/release-notes/index.md
+++ b/release-notes/index.md
@@ -7,6 +7,32 @@ category: release-notes
 title: What's new with Open Opportunities
 ---
 
+## Changes made February 5, 2021
+### Sitewide enhancements
+#### Skills Engine
+
+* Added a **Recommended opportunities** tab to the landing page for signed in users. This tab displays the first six recommended opportunities that match a user based on their profile (skills and biography) and the skills on an opportunity.
+* Added a **Good**, **Better** and **Best** indicator to matching opportunities. This helps a user know how well an opportunity matches their profile.
+* Updated the search results default to sort by **Profile match**.
+* Added a new **Profile match** filter on the search page to filter opportunities by good, better, and best match.
+
+### Other
+
+* Added a new toggle to the community attribute page so community managers can determine where applicant lists will display for all signed in users for opportunities posted in the community.
+* Added a new **Ambassador badge** to award users who are proactive supporters of Open Opportunities. The badge will display in the profile.
+* Made the location field required on the **Create opportunity** page for in-person opportunities.
+* Updated the series filter to show all series in a list.
+* Updated help center links to reflect new help center navigation.
+
+### Bug Fixes
+
+* Fixed several 508 compliance issues.
+* Limited the mm/dd/yyyy fields to 2 or 4 characters respectively.
+* Removed special characters appearing in some emails.
+* Updated a help link on the home page to open in a new window.
+* Resolved issue with emails going to participants login.gov email instead of federal email.
+* Resolved issues with mobile display of series on communities and community attribute page.
+
 ## Changes made January 22, 2021
 
 ### Sitewide enhancements
@@ -59,54 +85,7 @@ A future release will allow for us to suggest opportunities based on a user’s 
 * Fixed a display issue with the **Manage applicant** right rail when you undo **Task complete**.
 * Fixed issue so when you duplicate an opportunity it does not add the opportunity to the current user’s favorites.
 
-
-## Changes made October 16, 2020
-
-### Site-wide enhancements
-
-#### Changes to Communities
-
-Added the following updates to **Community** pages:
-
-* A **community profile summary** to the left-hand side of the page.
-* **Related skills** to the community profile page and individual community card.
-* **Series** to community profile page.
-* **Join** button so users can join a community.
-* **Leave community** button so users can leave a community.
-* Search function for **Communities**, including page count and total number of search results.
-* Ability to specify an alternate URL when a user clicks **View opportunity** from a community profile page.
-* Ability to add community profile page banners, which display at the top of the community profile page.
-* A new field to the **Manage community** page that captures the URL for information about participant requirements.
-* Removed **Community manager** label from members list on community profile page.
-* Updated the help text in the community members search box.
-
-#### Changes for Manage applicant flow
-
-* Added a **Display manage applicants** toggle to the **Manage Community** page.
-* Added the ability to add tasks to the Manage applicant view.
-* Added a **Manage applicant** link under each applicant name. The link displays after the creator clicks **Next step**.
-* Redesigned the right rail on an applicant’s application with the information from the **Manage applicant** view toggle.
-* Added ability for creators to edit the **Manage applicant** view on an applicant’s application.
-* Added a **Task** checklist to the right rail on the Manage applicant view.
-* Added a **Not complete** modal that displays when a creator tries to complete an opportunity, but not all applicants have been marked as Task complete.
-* Added a **Tasks not complete** modal that displays when a creator clicks **Complete task** for an applicant.
-
-#### Other changes
-
-•	Added a date range to the **Opportunity CSV** and **Applicant CSV**.
-•	Added a confirmation modal when a user clicks **Withdraw application**.
-•	Updated the “Official use” banner that displays at the top of the page.
-•	Updated user metrics on the **Administration** dashboard.
-•	Updated **Details** and **Laterals** to include a messaging after a user clicks **Next step** at the bottom of an opportunity page.
-
-### Bug fixes
-
-We fixed the following:
-
-* An issue with the statement of interest during the application process.
-* A page time-out issue caused by vanity URLs.
-* The “Alternate view opportunity URL” field to prevent users from entering bad data.
-
+[October 16, 2020](oct-16-2020)  
 [October 2, 2020](oct-02-2020)  
 [September 18, 2020](sep-18-2020)  
 [September 4, 2020](sep-04-2020)  

--- a/release-notes/oct-16-2020.md
+++ b/release-notes/oct-16-2020.md
@@ -1,0 +1,52 @@
+---
+permalink: release-notes/oct-16-2020/
+layout: default
+section: what-is-new
+category: what-is-new
+title: October 16, 2020
+---
+
+## Site-wide enhancements
+
+### Communities
+
+Added the following updates to **Community** pages:
+
+* A **community profile summary** to the left-hand side of the page.
+* **Related skills** to the community profile page and individual community card.
+* **Series** to community profile page.
+* **Join** button so users can join a community.
+* **Leave community** button so users can leave a community.
+* Search function for **Communities**, including page count and total number of search results.
+* Ability to specify an alternate URL when a user clicks **View opportunity** from a community profile page.
+* Ability to add community profile page banners, which display at the top of the community profile page.
+* A new field to the **Manage community** page that captures the URL for information about participant requirements.
+* Removed **Community manager** label from members list on community profile page.
+* Updated the help text in the community members search box.
+
+### Manage applicant flow
+
+* Added a **Display manage applicants** toggle to the **Manage Community** page.
+* Added the ability to add tasks to the Manage applicant view.
+* Added a **Manage applicant** link under each applicant name. The link displays after the creator clicks **Next step**.
+* Redesigned the right rail on an applicant’s application with the information from the **Manage applicant** view toggle.
+* Added ability for creators to edit the **Manage applicant** view on an applicant’s application.
+* Added a **Task** checklist to the right rail on the Manage applicant view.
+* Added a **Not complete** modal that displays when a creator tries to complete an opportunity, but not all applicants have been marked as Task complete.
+* Added a **Tasks not complete** modal that displays when a creator clicks **Complete task** for an applicant.
+
+### Other changes
+
+* Added a date range to the **Opportunity CSV** and **Applicant CSV**.
+* Added a confirmation modal when a user clicks **Withdraw application**.
+* Updated the “Official use” banner that displays at the top of the page.
+* Updated user metrics on the **Administration** dashboard.
+*	Updated **Details** and **Laterals** to include a messaging after a user clicks **Next step** at the bottom of an opportunity page.
+
+## Bug fixes
+
+We fixed the following:
+
+* An issue with the statement of interest during the application process.
+* A page time-out issue caused by vanity URLs.
+* The “Alternate view opportunity URL” field to prevent users from entering bad data.


### PR DESCRIPTION
Updated the following Open Opps help center pages:

Updated What's new/release notes - added Feb. 5 2021 release notes, created a page for Oct. 16 2020 release notes
Updated How to search to include skills engine content
Updated the what are badges page to include ambassador badge content
Added how to cancel an opportunity
Updated sidenav to include how to cancel an opportunity