### PR TITLE
Update withdraw-application.md

### DIFF
--- a/applicants/withdraw-application.md
+++ b/applicants/withdraw-application.md
@@ -16,22 +16,6 @@ To withdraw an application from an opportunity:
 4. Click **Withdraw your application**, located in the blue box. A message will appear to confirm you want to withdraw your application.
 5. Click **Withdraw**.
 
-## Withdraw an application from the U.S. Department of State Student Internship Program (Unpaid)
-
-If you’re no longer interested in the U.S. Department of State Student Internship Program (Unpaid), you can withdraw your application.
-
-You can only withdraw your application while the application period is still open.
-
-To withdraw your application from the student internship program:
-
-1. Sign into Open Opportunities.
-2. Click on your name in the navigation—you will go to your landing page.
-3. Look at the **Program** column and click the name of the application you want to withdraw—your application will open.
-4. Click **Withdraw**—a message will appear to confirm you want to withdraw your application.
-5. Click **Withdraw** again.
-
-If you withdraw your application, you will lose all of the information in the application. If you decide you still want to apply, you will need to create a new application and go through the process again.
-
 ### How to use updated profile information in an application
 
 Another reason to withdraw your application is if you updated your USAJOBS profile AFTER you submitted your application. If you want to use the updated profile information in your application, you need to withdraw your existing application and create a new one to pull over your USAJOBS profile information.


### PR DESCRIPTION
Removing:

## Withdraw an application from the U.S. Department of State Student Internship Program (Unpaid)

If you’re no longer interested in the U.S. Department of State Student Internship Program (Unpaid), you can withdraw your application.

You can only withdraw your application while the application period is still open.

To withdraw your application from the student internship program:

1. Sign into Open Opportunities.
2. Click on your name in the navigation—you will go to your landing page.
3. Look at the **Program** column and click the name of the application you want to withdraw—your application will open.
4. Click **Withdraw**—a message will appear to confirm you want to withdraw your application.
5. Click **Withdraw** again.

If you withdraw your application, you will lose all of the information in the application. If you decide you still want to apply, you will need to create a new application and go through the process again.