### PR TITLE
Fix permalink

### DIFF
--- a/release-notes/jun-2022.md
+++ b/release-notes/jun-2022.md
@@ -1,5 +1,5 @@
 ---
-permalink: release-notes/jun-2020/
+permalink: release-notes/jun-2022/
 layout: default
 section: what-is-new
 category: what-is-new


### PR DESCRIPTION
There's a broken link on the release notes pointing to June 2022 release note archive page. I fixed the permalink on the jun-2022 page, so the link should work once this is pushed out.